### PR TITLE
Update base-docker-image release.yml & build.yml 'platforms' parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           file: ./Dockerfile
@@ -41,6 +42,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           file: ./Dockerfile.core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           push: true
@@ -43,6 +44,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           push: true


### PR DESCRIPTION
Add the following line to the build and build core steps of both release.yml and build.yml:

    platforms: linux/amd64,linux/arm64

This will build architecture specific images for each node version of the base docker image.