### PR TITLE
add platforms to each github action yml file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         # NOTE: These versions must be kept in sync with the release.yml
         version: ["14.21.3", "16.20.0", "18.16.0"]
-        # platform: ["linux/amd64","linux/arm64"]
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,14 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with: 
+          platforms: linux/arm64,linux/amd64
       -
         name: Build
         uses: docker/build-push-action@v4
         with:
           context: .
-          # platforms: ${{ matrix.platform }}
+          platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           file: ./Dockerfile
@@ -43,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          # platforms: ${{ matrix.platform }}
+          platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           file: ./Dockerfile.core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           file: ./Dockerfile
-          tags: terascope/node-base:${{ matrix.version }}
+          tags: terascope/node-base:${{ matrix.version }}-test
       -
         name: Build Core
         uses: docker/build-push-action@v4
@@ -48,4 +48,4 @@ jobs:
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           file: ./Dockerfile.core
-          tags: terascope/node-base:${{ matrix.version }}-core
+          tags: terascope/node-base:${{ matrix.version }}-core-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
+          push: true
           file: ./Dockerfile
           tags: terascope/node-base:${{ matrix.version }}-test
       -
@@ -47,5 +48,6 @@ jobs:
           platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
+          push: true
           file: ./Dockerfile.core
           tags: terascope/node-base:${{ matrix.version }}-core-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,14 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/arm64,linux/amd64
       -
         name: Build
         uses: docker/build-push-action@v4
         with:
           context: .
-          # platforms: ${{ matrix.platform }}
+          platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           push: true
@@ -45,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          # platforms: ${{ matrix.platform }}
+          platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
           pull: true
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         # NOTE: These versions must be kept in sync with the build.yml
         version: ["14.21.3", "16.20.0", "18.16.0"]
-        # platform: ["linux/amd64","linux/arm64"]
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
I added ```platforms: linux/arm64,linux/amd64``` to each part of the build steps within the ```build.yml``` and ```release.yml``` files.

This should allow compatibility with arm64 architectures.

Issue number #14
