### PR TITLE
Add node twenty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the release.yml
-        version: ["16.20.2", "18.18.2", "20.8.1"]
+        version: ["16.20.2", "18.19.1", "20.11.1"]
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the build.yml
-        version: ["16.20.2", "18.18.2", "20.8.1"]
+        version: ["16.20.2", "18.19.1", "20.11.1"]
     runs-on: ubuntu-latest
     steps:
       -

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,14 +1,6 @@
 ARG NODE_VERSION
 FROM node:${NODE_VERSION}-alpine
 
-# use an older alpine registry for >=10.19
-# because otherwise requiring node-rdkafka breaks
-# linux amd64 (like CI)
-RUN if [ -z "${NODE_VERSION%%10*}" ]; then \
-    sed -i -e 's/v3.11/v3.9/g' /etc/apk/repositories \
-    && apk upgrade; \
-    fi
-
 RUN apk --no-cache add \
     bash \
     curl \

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ This project builds the Terascope base images [used by Teraslice](https://github
 
 With the terafoundation connectors builtin:
 
-- `terascope/node-base:14.21.3`
-- `terascope/node-base:16.20.0`
-- `terascope/node-base:18.16.0`
+- `terascope/node-base:20.11.1`
+- `terascope/node-base:18.19.1`
+- `terascope/node-base:16.20.2`
 
 Without: (this will save the image size by roughly 200MB)
 
-- `terascope/node-base:14.21.3-core`
-- `terascope/node-base:16.20.0-core`
-- `terascope/node-base:18.16.0-core`
+- `terascope/node-base:20.11.1-core`
+- `terascope/node-base:18.19.1-core`
+- `terascope/node-base:16.20.2-core`
 
 Check for the latest version tags here:
 
@@ -24,13 +24,13 @@ NodeJS version):
 ```bash
 # With connectors
 docker build --file Dockerfile --pull \
---build-arg NODE_VERSION=18.16.0 \
---tag terascope/node-base:18.16.0 .
+--build-arg NODE_VERSION=18.19.1 \
+--tag terascope/node-base:18.19.1 .
 
 # Without connectors
 docker build --file Dockerfile.core --pull \
---build-arg NODE_VERSION=18.16.0 \
---tag terascope/node-base:18.16.0-core .
+--build-arg NODE_VERSION=18.19.1 \
+--tag terascope/node-base:18.19.1-core .
 ```
 
 Double check the action output before relying on the above commands.


### PR DESCRIPTION
This PR does the following:

* Removes unneeded sed command
* Updates versions to "16.20.2", "18.19.1", "20.11.1"

Closes: https://github.com/terascope/base-docker-image/issues/9