### PR TITLE
Add fix for python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apk --no-cache add \
     bsd-compat-headers \
     py-setuptools
 
+# Check to see if distutils is installed because python 3.12 removed it
+RUN python3 -c "import distutils" || (apk update && apk add py3-setuptools)
+
 ENV NPM_CONFIG_LOGLEVEL error
 ENV WITH_SASL 0
 

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -14,6 +14,9 @@ RUN apk --no-cache add \
     cyrus-sasl-dev \
     python3
 
+# Check to see if distutils is installed because python 3.12 removed it
+RUN python3 -c "import distutils" || (apk update && apk add py3-setuptools)
+
 ENV NPM_CONFIG_LOGLEVEL error
 ENV WITH_SASL 0
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds a fix in the Dockerfile that checks to see if `distutils` exists, and if it doesn't then it installs `setuptools` which includes it.
  - This is because teraslice builds will fail without `distutils`

The node 22.2.0 alpine image for amd64 will install python `3.12` which will cause this issue. Below is a link with the new changes from python `3.11` to `3.12`:
https://www.python.org/downloads/release/python-3123/