### PR TITLE
Revert python fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ RUN apk --no-cache add \
     bsd-compat-headers \
     py-setuptools
 
-# Check to see if distutils is installed because python 3.12 removed it
-RUN python3 -c "import distutils" || (apk update && apk add py3-setuptools)
-
 ENV NPM_CONFIG_LOGLEVEL error
 ENV WITH_SASL 0
 

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -14,9 +14,6 @@ RUN apk --no-cache add \
     cyrus-sasl-dev \
     python3
 
-# Check to see if distutils is installed because python 3.12 removed it
-RUN python3 -c "import distutils" || (apk update && apk add py3-setuptools)
-
 ENV NPM_CONFIG_LOGLEVEL error
 ENV WITH_SASL 0
 


### PR DESCRIPTION
This PR makes the following changes:

- Removes a command in the dockerfile that checks for `distutils` python dependency