### PR TITLE
Rework node version tags workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the release.yml
-        version: ["18.19.1", "20.11.1", "22.2.0"]
+        version: ["18", "18.19", "18.19.1", 
+                  "20", "20.11", "20.11.1", 
+                  "22", "22.2", "22.2.0"]
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the release.yml
-        version: ["22"]
+        version: ["18", "20", "22"]
     runs-on: ubuntu-latest
 
     steps:
@@ -43,45 +43,53 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile
-          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-test"
-          cache-to: 
+          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-test" 
       -
         name: Grab Current Version
         id: current_version
-        run: echo "::set-output name=current_node_version::$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)"
-        # run: echo "CURRENT_NODE_VERSION=$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)" >> $GITHUB_ENV
+        # run: echo "::set-output name=current_node_version::$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)"
+        run: echo "CURRENT_NODE_VERSION=$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)" >> $GITHUB_ENV
       -
         name: Grab Minor Version
         id: minor_version
-        # run: echo "MINOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} minor)" >> $GITHUB_ENV
-        run: |
-          echo "::set-output name=minor::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} minor)"
+        run: echo "MINOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} minor)" >> $GITHUB_ENV
+        # run: |
+        #   echo "::set-output name=minor::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} minor)"
 
       -
         name: Grab Patch Version
         id: patch_version
-        # run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
-        run: |
-          echo "::set-output name=patch::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} patch)"
+        run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
+        # run: |
+        #   echo "::set-output name=patch::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} patch)"
 
+      # - 
+      #   name: Retag, and push image
+      #   run: |
+      #     docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+      #     docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
+      #     docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+      #     docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
       - 
         name: Retag, and push image
         run: |
-          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
-          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
-      -
-        name: Build Core
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/arm64,linux/amd64
-          build-args: "NODE_VERSION=${{ matrix.version }}"
-          pull: true
-          push: true
-          file: ./Dockerfile.core
-          tags: | 
-            "${{ env.IMAGE_NAME }}:${{ matrix.version }}-core-test"
-            "${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-core-test"
-            "${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-core-test"
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}-test
+
+# I don't think we use the core images and we should consider removing this and the Dockerfile.core file.
+      # -
+      #   name: Build Core
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     context: .
+      #     platforms: linux/arm64,linux/amd64
+      #     build-args: "NODE_VERSION=${{ matrix.version }}"
+      #     pull: true
+      #     push: true
+      #     file: ./Dockerfile.core
+      #     tags: | 
+      #       "${{ env.IMAGE_NAME }}:${{ matrix.version }}-core-test"
+      #       "${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-core-test"
+      #       "${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-core-test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ["18", "20", "22.4.1"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,21 +17,21 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
       -
         name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64
@@ -42,7 +42,7 @@ jobs:
           tags: terascope/node-base:${{ matrix.version }}-test
       -
         name: Build Core
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ["18.19.1", "20", "22"]
     runs-on: ubuntu-latest
 
     steps:
@@ -60,12 +60,35 @@ jobs:
         id: patch_version
         run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
       - 
+        name: Check for specific node version
+        id: check_specific_version
+        run: |
+          if [[ "${{ matrix.version }}" == *.* ]]; then
+            echo "SPECIFIC_VERSION=true" >> $GITHUB_ENV
+          else
+            echo "SPECIFIC_VERSION=false" >> $GITHUB_ENV
+          fi
+      -
+        name: Grab Major Version
+        if: ${{ env.SPECIFIC_VERSION}} == 'true'        
+        id: major_version
+        run: echo "MAJOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} major)" >> $GITHUB_ENV
+      - 
         name: Retag, and push minor/patch images
+        if: ${{ env.SPECIFIC_VERSION}} == 'false'
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}-test
+      - 
+        name: Retag, and push major/minor images
+        if: ${{ env.SPECIFIC_VERSION}} == 'true'
+        run: |
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}-test
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}-test
 
 # I don't think we use the core images and we should consider removing this and the Dockerfile.core file.
       # -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,12 +70,12 @@ jobs:
           fi
       -
         name: Grab Major Version
-        if: ${{ env.SPECIFIC_VERSION}} == 'true'        
+        if: ${{ env.SPECIFIC_VERSION == 'true' }}
         id: major_version
         run: echo "MAJOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} major)" >> $GITHUB_ENV
       - 
         name: Retag, and push minor/patch images
-        if: ${{ env.SPECIFIC_VERSION}} == 'false'
+        if: ${{ env.SPECIFIC_VERSION == 'false' }}
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test
@@ -83,7 +83,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}-test
       - 
         name: Retag, and push major/minor images
-        if: ${{ env.SPECIFIC_VERSION}} == 'true'
+        if: ${{ env.SPECIFIC_VERSION == 'true' }}
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         id: patch_version
         run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
       - 
-        name: Retag, and push image
+        name: Retag, and push minor/patch images
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,29 +47,15 @@ jobs:
       -
         name: Grab Current Version
         id: current_version
-        # run: echo "::set-output name=current_node_version::$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)"
         run: echo "CURRENT_NODE_VERSION=$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)" >> $GITHUB_ENV
       -
         name: Grab Minor Version
         id: minor_version
         run: echo "MINOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} minor)" >> $GITHUB_ENV
-        # run: |
-        #   echo "::set-output name=minor::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} minor)"
-
       -
         name: Grab Patch Version
         id: patch_version
         run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
-        # run: |
-        #   echo "::set-output name=patch::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} patch)"
-
-      # - 
-      #   name: Retag, and push image
-      #   run: |
-      #     docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
-      #     docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
-      #     docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
-      #     docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
       - 
         name: Retag, and push image
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,25 +7,35 @@ on:
       - '*'
       - '!master'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/node-base
+      
 jobs:
   build_matrix:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the release.yml
-        version: ["18", "18.19", "18.19.1", 
-                  "20", "20.11", "20.11.1", 
-                  "22", "22.2", "22.2.0"]
+        version: ["22"]
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
       -
-        name: Login to Docker Hub
+        name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -41,7 +51,34 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile
-          tags: terascope/node-base:${{ matrix.version }}-test
+          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-test"
+          cache-to: 
+      -
+        name: Grab Current Version
+        id: current_version
+        run: echo "::set-output name=current_node_version::$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)"
+        # run: echo "CURRENT_NODE_VERSION=$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test node -v)" >> $GITHUB_ENV
+      -
+        name: Grab Minor Version
+        id: minor_version
+        # run: echo "MINOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} minor)" >> $GITHUB_ENV
+        run: |
+          echo "::set-output name=minor::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} minor)"
+
+      -
+        name: Grab Patch Version
+        id: patch_version
+        # run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
+        run: |
+          echo "::set-output name=patch::$(node extract-semver.js ${{ steps.current_version.outputs.current_node_version }} patch)"
+
+      - 
+        name: Retag, and push image
+        run: |
+          docker tag ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
+          docker push ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
+          docker tag ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
+          docker push ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
       -
         name: Build Core
         uses: docker/build-push-action@v6
@@ -52,4 +89,7 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile.core
-          tags: terascope/node-base:${{ matrix.version }}-core-test
+          tags: | 
+            "${{ env.IMAGE_NAME }}:${{ matrix.version }}-core-test"
+            "${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-core-test"
+            "${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-core-test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the release.yml
+        # In the case where a new node version introduces a breaking change,
+        # replace the major version of the matrix to a pinned version here.
+        # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
         version: ["18", "20", "22"]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
       - '!master'
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/node-base
       
 jobs:
@@ -19,12 +18,6 @@ jobs:
         version: ["22"]
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
     steps:
       -
         name: Checkout
@@ -33,9 +26,8 @@ jobs:
         name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18.19.1", "20", "22"]
+        version: ["18", "20", "22"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,10 @@ jobs:
       - 
         name: Retag, and push image
         run: |
-          docker tag ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
-          docker push ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
-          docker tag ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
-          docker push ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}-test
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test ${{ env.IMAGE_NAME }}:${{ matrix.version }}-test
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ steps.minor_version.outputs.minor }}.${{ steps.patch_version.outputs.patch }}-test
       -
         name: Build Core
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,12 @@ jobs:
           fi
       -
         name: Grab Major Version
-        if: ${{ env.SPECIFIC_VERSION}} == 'true'        
+        if: ${{ env.SPECIFIC_VERSION == 'true' }}       
         id: major_version
         run: echo "MAJOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} major)" >> $GITHUB_ENV
       - 
         name: Retag, and push minor/patch images
-        if: ${{ env.SPECIFIC_VERSION}} == 'false'
+        if: ${{ env.SPECIFIC_VERSION == 'false' }}
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}
@@ -83,7 +83,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}
       - 
         name: Retag, and push major/minor images
-        if: ${{ env.SPECIFIC_VERSION}} == 'true'
+        if: ${{ env.SPECIFIC_VERSION == 'true' }}
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,16 @@ on:
     - cron: '30 5 * * 0'  # Sunday's at 0530
   workflow_dispatch:
 
+env:
+  IMAGE_NAME: ${{ github.repository_owner }}/node-base
+
 jobs:
   build_and_release_matrix:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the build.yml
-        version: ["18", "18.19", "18.19.1", 
-                  "20", "20.11", "20.11.1", 
-                  "22", "22.2", "22.2.0"]
-
+        version: ["18", "20", "22"]
     runs-on: ubuntu-latest
-
     steps:
       -
         name: Checkout
@@ -46,16 +45,37 @@ jobs:
           file: ./Dockerfile
           tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}"
       -
-        name: Build Core
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/arm64,linux/amd64
-          build-args: "NODE_VERSION=${{ matrix.version }}"
-          pull: true
-          push: true
-          file: ./Dockerfile.core
-          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-core"
+        name: Grab Current Version
+        id: current_version
+        run: echo "CURRENT_NODE_VERSION=$(docker run ${{ env.IMAGE_NAME }}:${{ matrix.version }} node -v)" >> $GITHUB_ENV
+      -
+        name: Grab Minor Version
+        id: minor_version
+        run: echo "MINOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} minor)" >> $GITHUB_ENV
+      -
+        name: Grab Patch Version
+        id: patch_version
+        run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
+      - 
+        name: Retag, and push minor/patch images
+        run: |
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}
+    
+# I don't think we use the core images and we should consider removing this and the Dockerfile.core file.
+      # -
+      #   name: Build Core
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     context: .
+      #     platforms: linux/arm64,linux/amd64
+      #     build-args: "NODE_VERSION=${{ matrix.version }}"
+      #     pull: true
+      #     push: true
+      #     file: ./Dockerfile.core
+      #     tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-core"
 
       # Look into this more:
       # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,21 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
       -
         name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64
@@ -43,7 +43,7 @@ jobs:
           tags: terascope/node-base:${{ matrix.version }}
       -
         name: Build Core
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the build.yml
-        version: ["18.19.1", "20.11.1", "22.2.0"]
+        version: ["18", "18.19", "18.19.1", 
+                  "20", "20.11", "20.11.1", 
+                  "22", "22.2", "22.2.0"]
+
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ on:
     - cron: '30 5 * * 0'  # Sunday's at 0530
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/node-base
-
 jobs:
   build_and_release_matrix:
     strategy:
@@ -23,12 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
     steps:
       -
         name: Checkout
@@ -37,9 +27,8 @@ jobs:
         name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         # NOTE: These versions must be kept in sync with the build.yml
+        # In the case where a new node version introduces a breaking change,
+        # replace the major version of the matrix to a pinned version here.
+        # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
         version: ["18", "20", "22"]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ["18", "20", "22.4.1"]
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,35 @@ jobs:
         id: patch_version
         run: echo "PATCH=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} patch)" >> $GITHUB_ENV
       - 
+        name: Check for specific node version
+        id: check_specific_version
+        run: |
+          if [[ "${{ matrix.version }}" == *.* ]]; then
+            echo "SPECIFIC_VERSION=true" >> $GITHUB_ENV
+          else
+            echo "SPECIFIC_VERSION=false" >> $GITHUB_ENV
+          fi
+      -
+        name: Grab Major Version
+        if: ${{ env.SPECIFIC_VERSION}} == 'true'        
+        id: major_version
+        run: echo "MAJOR=$(node extract-semver.js ${{ env.CURRENT_NODE_VERSION }} major)" >> $GITHUB_ENV
+      - 
         name: Retag, and push minor/patch images
+        if: ${{ env.SPECIFIC_VERSION}} == 'false'
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ matrix.version }}.${{ env.MINOR }}.${{ env.PATCH }}
+      - 
+        name: Retag, and push major/minor images
+        if: ${{ env.SPECIFIC_VERSION}} == 'true'
+        run: |
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}
     
 # I don't think we use the core images and we should consider removing this and the Dockerfile.core file.
       # -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
     - cron: '30 5 * * 0'  # Sunday's at 0530
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/node-base
+
 jobs:
   build_and_release_matrix:
     strategy:
@@ -18,16 +22,24 @@ jobs:
                   "22", "22.2", "22.2.0"]
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
       -
-        name: Login to Docker Hub
+        name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,7 +55,7 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile
-          tags: terascope/node-base:${{ matrix.version }}
+          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}"
       -
         name: Build Core
         uses: docker/build-push-action@v6
@@ -54,4 +66,13 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile.core
-          tags: terascope/node-base:${{ matrix.version }}-core
+          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-core"
+
+      # Look into this more:
+      # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+      # - name: Generate artifact attestation
+      #   uses: actions/attest-build-provenance@v1
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+      #     subject-digest: ${{ steps.build_and_release_matrix.outputs.digest }}
+      #     push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,8 @@ COPY wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENV NODE_OPTIONS "--max-old-space-size=2048"
 
+LABEL node_version="$NODE_VERSION"
+LABEL kafka_connector_version="1.0.0"
+
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -37,5 +37,7 @@ COPY wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENV NODE_OPTIONS "--max-old-space-size=2048"
 
+LABEL node_version="$NODE_VERSION"
+
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Terascope Base Docker images
 
-This project builds the Terascope base images [used by Teraslice](https://github.com/terascope/teraslice/blob/master/Dockerfile#L1).  Below are the latest docker image tags.
+This project builds the Terascope base images [used by Teraslice](https://github.com/terascope/teraslice/blob/master/Dockerfile#L1).  Below are the latest docker image tags. Tags with only a major version use the latest minor and patch version. Tags with major/minor use the latest patch version. 
 
 With the terafoundation connectors builtin:
 
-- `terascope/node-base:22.2.0`
-- `terascope/node-base:20.11.1`
-- `terascope/node-base:18.19.1`
+- `terascope/node-base:22`
+- `terascope/node-base:20`
+- `terascope/node-base:18`
+- `terascope/node-base:22.*.*`
+- `terascope/node-base:20.*.*`
+- `terascope/node-base:18.*.*`
 
 Without: (this will save the image size by roughly 200MB)
+
+**_DEPRECATED:_** Core images are no longer built and pushed to docker.hub.  
 
 - `terascope/node-base:22.2.0-core`
 - `terascope/node-base:20.11.1-core`

--- a/extract-semver.js
+++ b/extract-semver.js
@@ -23,9 +23,9 @@ if (rawSemver === undefined || rawSemver === null) {
 if (
     type === undefined || 
     type === null ||
-    (type !== 'minor' &&  type !== 'patch')
+    (type !== 'minor' &&  type !== 'patch' && type !== 'major')
 ) {
-    throw new Error('You must define a type of either "minor" or "patch" as the second argument.');
+    throw new Error('You must define a type of either "major" "minor" or "patch" as the second argument.');
 }
 
 function getSemverPart(semver, part) {
@@ -39,12 +39,14 @@ function getSemverPart(semver, part) {
         throw new Error('Invalid semver format');
     }
     switch (part) {
+        case 'major':
+          return parseInt(match[1], 10);
         case 'minor':
           return parseInt(match[2], 10);
         case 'patch':
           return parseInt(match[3], 10);
         default:
-          throw new Error('Invalid part specified. Use "minor" or "patch".');
+          throw new Error('Invalid part specified. Use "major", "minor" or "patch".');
     }
 }
 

--- a/extract-semver.js
+++ b/extract-semver.js
@@ -1,0 +1,52 @@
+'use strict'
+
+let rawSemver = process.argv[2];
+const type = process.argv[3];
+
+function isValidSemver(version) {
+  // Remove leading 'v' if present
+  if (version.startsWith('v')) {
+    version = version.slice(1);
+  }
+    const semverRegex = /^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+    return semverRegex.test(version);
+}
+
+if (rawSemver === undefined || rawSemver === null) {
+    throw new Error(`Input of first arg is undefined! Input a valid semver.`);
+} else if (typeof rawSemver !== 'string') {
+    throw new Error(`Input must be a string! Got ${typeof rawSemver}`);
+} else if (!isValidSemver(rawSemver)) {
+    throw new Error(`Input ${rawSemver} is not a valid semver format`);
+}
+
+if (
+    type === undefined || 
+    type === null ||
+    (type !== 'minor' &&  type !== 'patch')
+) {
+    throw new Error('You must define a type of either "minor" or "patch" as the second argument.');
+}
+
+function getSemverPart(semver, part) {
+    // Remove leading 'v' if present
+    if (semver.startsWith('v')) {
+        semver = semver.slice(1);
+    }
+    const semverRegex = /^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+    const match = semver.match(semverRegex);
+    if (!match) {
+        throw new Error('Invalid semver format');
+    }
+    switch (part) {
+        case 'minor':
+          return parseInt(match[2], 10);
+        case 'patch':
+          return parseInt(match[3], 10);
+        default:
+          throw new Error('Invalid part specified. Use "minor" or "patch".');
+    }
+}
+
+
+process.stdout.write(getSemverPart(rawSemver, type).toString());


### PR DESCRIPTION
This PR makes the following changes:

- ***Important:*** Removed the building and publishing of `terascope/node-base-core` images
  - This is because there isn't a known use-case for this image 
- Updated the following github actions:
  - **actions/checkout** from `v3` to `v4`
  - **docker/login-action** from `v2` to `v3`
  - **docker/setup-buildx-action** from `v2` to `v3`
  - **docker/build-push-action** from `v4` to `v6`
- Added new workflow that will build and update image tags based off of the latest major node versions
- Added the following labels to the image:
  - `node_version`
  - `kafka_connector_version`

Ref to issue https://github.com/terascope/teraslice/issues/3683