### PR TITLE
Migrate docker images from docker.hub to ghcr registry 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           platforms: linux/arm64,linux/amd64
       -
+        name: check name
+        run: echo ${{ github.repository }}
+      -
         name: Build
         uses: docker/build-push-action@v6
         with:
@@ -79,7 +82,6 @@ jobs:
           else
             echo "SPECIFIC_VERSION=false" >> $GITHUB_ENV
           fi
-          echo ${{ github.repository }}
       -
         name: Grab Major Version
         if: ${{ env.SPECIFIC_VERSION == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - '!master'
 
 env:
-  IMAGE_NAME: ${{ github.repository_owner }}/node-base
+  IMAGE_NAME: ${{ github.repository }}
       
 jobs:
   build_matrix:
@@ -47,9 +47,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
-      -
-        name: check name
-        run: echo ${{ github.repository }}
       -
         name: Build
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
+          provenance: false
+          sbom: false
           pull: true
           push: true
           file: ./Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile
-          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-test" 
+          tags: "ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.version }}-test" 
       -
         name: Grab Current Version
         id: current_version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22.4.1"]
+        version: ["18", "20", "22"]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,15 @@ jobs:
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
         version: ["18", "20", "22.4.1"]
     runs-on: ubuntu-latest
+    # permissions:
+    #   packages: write
+    #   contents: read
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
 
     steps:
       -
@@ -29,8 +38,9 @@ jobs:
         name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
+          visibility: public
           pull: true
           push: true
           file: ./Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,19 @@ jobs:
         with:
           platforms: linux/arm64,linux/amd64
       -
+        name: Get timestamp for docker build
+        id: docker_time_stamp
+        run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
+      -
         name: Build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64
-          build-args: "NODE_VERSION=${{ matrix.version }}"
+          build-args: |
+            "NODE_VERSION=${{ matrix.version }}"
+            "GITHUB_SHA=${{ github.sha }}"
+            "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
           provenance: false
           sbom: false
           pull: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,9 @@ on:
       - '!master'
 
 env:
-  IMAGE_NAME: ${{ github.repository }}
+  # IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/node-base
       
 jobs:
   build_matrix:
@@ -39,7 +41,7 @@ jobs:
         name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
@@ -57,7 +59,7 @@ jobs:
           pull: true
           push: true
           file: ./Dockerfile
-          tags: "ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.version }}-test" 
+          tags: "${{ env.IMAGE_NAME }}:${{ matrix.version }}-test" 
       -
         name: Grab Current Version
         id: current_version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22.4.1"]
+        version: ["18"]
+        # version: ["18", "20", "22.4.1"]
     runs-on: ubuntu-latest
     # permissions:
     #   packages: write
@@ -78,6 +79,7 @@ jobs:
           else
             echo "SPECIFIC_VERSION=false" >> $GITHUB_ENV
           fi
+          echo ${{ github.repository }}
       -
         name: Grab Major Version
         if: ${{ env.SPECIFIC_VERSION == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
       - '!master'
 
 env:
-  # IMAGE_NAME: ${{ github.repository }}
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/node-base
       
@@ -20,18 +19,13 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18"]
-        # version: ["18", "20", "22.4.1"]
+        version: ["18", "20", "22.4.1"]
     runs-on: ubuntu-latest
-    # permissions:
-    #   packages: write
-    #   contents: read
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-
 
     steps:
       -
@@ -56,7 +50,6 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
-          visibility: public
           pull: true
           push: true
           file: ./Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           build-args: "NODE_VERSION=${{ matrix.version }}"
+          provenance: false
+          sbom: false
           pull: true
           push: true
           file: ./Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22.4.1"]
+        version: ["18", "20", "22"]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME: ${{ github.repository_owner }}/node-base
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/node-base
 
 jobs:
   build_and_release_matrix:
@@ -21,6 +22,12 @@ jobs:
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
         version: ["18", "20", "22.4.1"]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
       -
         name: Checkout
@@ -29,8 +36,9 @@ jobs:
         name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,19 @@ jobs:
         with:
           platforms: linux/arm64,linux/amd64
       -
+        name: Get timestamp for docker build
+        id: docker_time_stamp
+        run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
+      -
         name: Build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64
-          build-args: "NODE_VERSION=${{ matrix.version }}"
+          build-args: |
+            "NODE_VERSION=${{ matrix.version }}"
+            "GITHUB_SHA=${{ github.sha }}"
+            "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
           provenance: false
           sbom: false
           pull: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,8 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
   org.opencontainers.image.title="Node-base" \
   org.opencontainers.image.vendor="Terascope" \
-  node_version="$NODE_VERSION" \
-  kafka_connector_version="1.0.0"
+  io.terascope.image.node_version="$NODE_VERSION" \
+  io.terascope.image.kafka_connector_version="1.0.0"
 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,8 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
   org.opencontainers.image.title="Node-base" \
   org.opencontainers.image.vendor="Terascope" \
-  org.opencontainers.image.node_version="$NODE_VERSION" \
-  org.opencontainers.image.kafka_connector_version="1.0.0"
+  node_version="$NODE_VERSION" \
+  kafka_connector_version="1.0.0"
 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ARG NODE_VERSION
 FROM node:${NODE_VERSION}-alpine
 
+ARG GITHUB_SHA
+ARG BUILD_TIMESTAMP
+
 RUN apk --no-cache add \
     bash \
     curl \
@@ -67,8 +70,15 @@ COPY wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENV NODE_OPTIONS "--max-old-space-size=2048"
 
-LABEL node_version="$NODE_VERSION"
-LABEL kafka_connector_version="1.0.0"
+LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
+  org.opencontainers.image.documentation="https://github.com/terascope/base-docker-image/blob/master/README.md" \
+  org.opencontainers.image.licenses="MIT License" \
+  org.opencontainers.image.revision="$GITHUB_SHA" \
+  org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
+  org.opencontainers.image.title="Node-base" \
+  org.opencontainers.image.vendor="Terascope" \
+  org.opencontainers.image.node_version="$NODE_VERSION" \
+  org.opencontainers.image.kafka_connector_version="1.0.0"
 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -47,6 +47,6 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
   org.opencontainers.image.title="Node-base-core" \
   org.opencontainers.image.vendor="Terascope" \
-  node_version="$NODE_VERSION" 
+  io.terascope.image.node_version="$NODE_VERSION" 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,6 +1,9 @@
 ARG NODE_VERSION
 FROM node:${NODE_VERSION}-alpine
 
+ARG GITHUB_SHA
+ARG BUILD_TIMESTAMP
+
 RUN apk --no-cache add \
     bash \
     curl \
@@ -37,7 +40,13 @@ COPY wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENV NODE_OPTIONS "--max-old-space-size=2048"
 
-LABEL node_version="$NODE_VERSION"
-
+LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
+  org.opencontainers.image.documentation="https://github.com/terascope/base-docker-image/blob/master/README.md" \
+  org.opencontainers.image.licenses="MIT License" \
+  org.opencontainers.image.revision="$GITHUB_SHA" \
+  org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
+  org.opencontainers.image.title="Node-base-core" \
+  org.opencontainers.image.vendor="Terascope" \
+  org.opencontainers.image.node_version="$NODE_VERSION" 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -47,6 +47,6 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
   org.opencontainers.image.title="Node-base-core" \
   org.opencontainers.image.vendor="Terascope" \
-  org.opencontainers.image.node_version="$NODE_VERSION" 
+  node_version="$NODE_VERSION" 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ Check for the latest version tags here:
 
 https://github.com/terascope/base-docker-image/pkgs/container/node-base
 
+## Pulling node-base image from ghcr.io
+
+Pulling an image can be used with the `docker pull` command:
+```
+docker pull ghcr.io/terascope/node-base:20
+```
+
+A known issue with pulling an image from ghcr is when a token expires, it will pop up with a `denied` error when pulling.
+
+```
+Error response from daemon: Head "https://ghcr.io/v2/terascope/node-base/manifests/20": denied: denied
+```
+
+To resolve this you can logout of the `ghcr.oi` registry. Signing back in isn't nessesary:
+```
+docker logout ghcr.io
+```
+
 At the moment, manual builds can be done like this (substitute the appropriate
 NodeJS version):
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ Without: (this will save the image size by roughly 200MB)
 
 **_DEPRECATED:_** Core images are no longer built and pushed to docker.hub.  
 
-- `terascope/node-base:22.2.0-core`
-- `terascope/node-base:20.11.1-core`
-- `terascope/node-base:18.19.1-core`
+- `terascope/node-base:22-core`
+- `terascope/node-base:20-core`
+- `terascope/node-base:18-core`
+- `terascope/node-base:22.*.*-core`
+- `terascope/node-base:20.*.*-core`
+- `terascope/node-base:18.*.*-core`
 
 Check for the latest version tags here:
 
-https://hub.docker.com/r/terascope/node-base/tags
+https://github.com/terascope/base-docker-image/pkgs/container/node-base
 
 At the moment, manual builds can be done like this (substitute the appropriate
 NodeJS version):
@@ -29,13 +32,13 @@ NodeJS version):
 ```bash
 # With connectors
 docker build --file Dockerfile --pull \
---build-arg NODE_VERSION=18.19.1 \
---tag terascope/node-base:18.19.1 .
+--build-arg NODE_VERSION=18 \
+--tag ghcr.io/terascope/node-base:18 .
 
 # Without connectors
 docker build --file Dockerfile.core --pull \
---build-arg NODE_VERSION=18.19.1 \
---tag terascope/node-base:18.19.1-core .
+--build-arg NODE_VERSION=18 \
+--tag ghcr.io/terascope/node-base:18-core .
 ```
 
 Double check the action output before relying on the above commands.
@@ -44,6 +47,18 @@ Double check the action output before relying on the above commands.
 
 - Docker image builds will happen on any push to any branch other than `master`.
 - When a Github release is made, the image will be built and then pushed to
-docker hub.
+the github container registry.
+
+**NOTE:** _When making changes to the github workflows, the node matrix array only supports either a major node version or a full specific node version. Ex: [18, 22.4.1]. Adding a major-minor version like "18.19" is not supported as of right now._
+
+### How tags and node versions are released in the workflow
+
+The workflow for the base image tags is closely linked to the Node.js version used in the image. Here's a simple breakdown of how it works:
+
+**Major Version Tag:** The image will either grab the latest available version of a specific major Node.js release from the node alpine image(e.g., Node 18) or it will be pinned to the latest node version that is compatible with the base image. This image is tagged with the major version number (e.g., 18). So in some cases this version will be pinned and not completely up to date with a node release. This tag is always overwritten on release.
+
+**Major-Minor Version Tag:** Next, it will retag and include both the major and minor version numbers (e.g., 18.14). This tag is updated to reflect the latest minor release within the specified major version. This tag will get overwritten in the case of a node-base change or if a new patch is relased for this minor version of node.
+
+**Major-Minor-Patch Version Tag:** Finally, the image will be re-tagged again with the complete version number, including the major, minor, and patch versions (e.g., 18.14.2). This tag points to a specific version of the Node.js release. This image only gets overwritten on a change to the node-base image that isn't node version related.
 
 The build and publishing is done by Github Actions.


### PR DESCRIPTION
This PR makes the following changes;

- Moves docker registry from `docker.hub` to `ghcr.io`(github container registry)
- Added more descriptive labels using the proper format stated here https://github.com/terascope/teraslice/issues/3257
- Fixes `unknown/unknown` architecture that shows up in the image digest to no longer be there
- Updates `Readme` to describe release workflow more clearly 
- Unpin node `22` 