### PR TITLE
Fix CI segfault issue with ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
         name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.12.0
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
         version: ["18", "20", "22"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
         name: Build
-        uses: docker/build-push-action
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
-          version: v0.19.3
       -
         name: Get timestamp for docker build
         id: docker_time_stamp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
+          version: v0.19.3
       -
         name: Get timestamp for docker build
         id: docker_time_stamp
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
         name: Build
-        uses: docker/build-push-action@v6.12.0
+        uses: docker/build-push-action
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
         version: ["18", "20", "22"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
+          version: v0.19.3
       -
         name: Get timestamp for docker build
         id: docker_time_stamp
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
         name: Build
-        uses: docker/build-push-action@v6.12.0
+        uses: docker/build-push-action
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
         name: Build
-        uses: docker/build-push-action
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64,linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/arm64,linux/amd64
-          version: v0.19.3
       -
         name: Get timestamp for docker build
         id: docker_time_stamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
         name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.12.0
         with:
           context: .
           platforms: linux/arm64,linux/amd64


### PR DESCRIPTION
This PR sets the runner version to Ubuntu-22.04. Hopefully this will fix seg fault errors in CI when using ubuntu-24.04.
ref: #37 