### PR TITLE
Test Memory Leak - Revert terafoundation_kafka_connector to 1.0.0, pin node version to 22.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ["18", "20", "22.12.0"] # pinning node 22 for testing purposes, revert after tests
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ["18", "20", "22.12.0"] # pinning node 22 for testing purposes, revert after tests
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN npm init --yes &> /dev/null \
     --build \
     --no-package-lock \
     --no-optional \
-    'terafoundation_kafka_connector@~1.2.1' \
+    'terafoundation_kafka_connector@~1.0.0' \
     && npm cache clean --force
 
 RUN apk del .build-deps
@@ -78,7 +78,7 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.title="Node-base" \
   org.opencontainers.image.vendor="Terascope" \
   io.terascope.image.node_version="$NODE_VERSION" \
-  io.terascope.image.kafka_connector_version="1.2.1"
+  io.terascope.image.kafka_connector_version="1.0.0"
 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
This PR makes the following changes:
- set the terafoundation_kafka_connector to version 1.0.0 in the Dockerfile
- pin the node version to 22.12.0 in the release.yml and build.yml workflows

This base image will be used to test a memory leak and should be reverted when testing is finished.