### PR TITLE
revert test changes, fix ENV declarations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22.12.0"] # pinning node 22 for testing purposes, revert after tests
+        version: ["18", "20", "22"]
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         # In the case where a new node version introduces a breaking change,
         # replace the major version of the matrix to a pinned version here.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22.12.0"] # pinning node 22 for testing purposes, revert after tests
+        version: ["18", "20", "22"]
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN apk --no-cache add \
     bsd-compat-headers \
     py-setuptools
 
-ENV NPM_CONFIG_LOGLEVEL error
-ENV WITH_SASL 0
+ENV NPM_CONFIG_LOGLEVEL=error
+ENV WITH_SASL=0
 
 RUN node --version
 RUN yarn --version
@@ -55,7 +55,7 @@ RUN npm init --yes &> /dev/null \
     --build \
     --no-package-lock \
     --no-optional \
-    'terafoundation_kafka_connector@~1.0.0' \
+    'terafoundation_kafka_connector@~1.2.1' \
     && npm cache clean --force
 
 RUN apk del .build-deps
@@ -68,7 +68,7 @@ RUN node --print --eval "require('node-rdkafka')"
 COPY docker-pkg-fix.js /usr/local/bin/docker-pkg-fix
 COPY wait-for-it.sh /usr/local/bin/wait-for-it
 
-ENV NODE_OPTIONS "--max-old-space-size=2048"
+ENV NODE_OPTIONS="--max-old-space-size=2048"
 
 LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.documentation="https://github.com/terascope/base-docker-image/blob/master/README.md" \
@@ -78,7 +78,7 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.title="Node-base" \
   org.opencontainers.image.vendor="Terascope" \
   io.terascope.image.node_version="$NODE_VERSION" \
-  io.terascope.image.kafka_connector_version="1.0.0"
+  io.terascope.image.kafka_connector_version="1.2.1"
 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
This PR makes the following changes:
- revert changes from #39 used to test memory leak
  - terafoundation_kafka_connector from 1.0.0 to 1.2.1
  - unpin node 22 version in build and release workflows
- fix `Dockerfile` LegacyKeyValueFormat warnings (see: #40)