### PR TITLE
Automate releases

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# This file stores variables used by build.yml and release.yml as build-args
+# If IMAGE_VERSION is updated then a new release 
+# will be created with that tag on merge to master
+
+TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.2.1
+IMAGE_VERSION=1.2.2

--- a/.env
+++ b/.env
@@ -1,6 +1,9 @@
-# This file stores variables used by build.yml and release.yml as build-args
+# This file stores variables used by build.yml and release.yml
+
 # If IMAGE_VERSION is updated then a new release 
 # will be created with that tag on merge to master
+IMAGE_VERSION=1.2.2
 
 TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.2.1
-IMAGE_VERSION=1.2.2
+ 
+NODE_VERSIONS_ARRAY=["18", "20", "22"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
             "IMAGE_VERSION=${{ steps.dotenv.outputs.IMAGE_VERSION }}"
           provenance: false
-          sbom: false
+          sbom: true
           pull: true
           push: true
           file: ./Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
       NODE_VERSIONS_ARRAY: ${{ steps.dotenv.outputs.NODE_VERSIONS_ARRAY }}
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         name: Get versions from .env file using Dotenv Action
         id: dotenv
         uses: falti/dotenv-action@v1.1.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,30 @@ env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/node-base
       
 jobs:
+  compute-versions-from-env:
+    runs-on: ubuntu-latest
+    outputs:
+      TERAFOUNDATION_KAFKA_CONNECTOR_VERSION: ${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}
+      IMAGE_VERSION: ${{ steps.dotenv.outputs.IMAGE_VERSION }}
+      NODE_VERSIONS_ARRAY: ${{ steps.dotenv.outputs.NODE_VERSIONS_ARRAY }}
+    steps:
+      -
+        name: Get versions from .env file using Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+          keys-case: bypass
+
   build_matrix:
+    needs: 'compute-versions-from-env'
     strategy:
       matrix:
-        # NOTE: These versions must be kept in sync with the release.yml
+        # NOTE: The NODE_VERSION_ARRAY is stored in the .env file.
         # In the case where a new node version introduces a breaking change,
-        # replace the major version of the matrix to a pinned version here.
+        # replace the major version of the matrix to a pinned version.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ${{ fromJSON(needs.compute-versions-from-env.outputs.NODE_VERSIONS_ARRAY) }}
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -48,13 +64,6 @@ jobs:
         id: docker_time_stamp
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
-        name: Get versions from .env file using Dotenv Action
-        id: dotenv
-        uses: falti/dotenv-action@v1.1.4
-        with:
-          log-variables: true
-          keys-case: bypass
-      -
         name: Build
         uses: docker/build-push-action@v6
         with:
@@ -64,8 +73,8 @@ jobs:
             "NODE_VERSION=${{ matrix.version }}"
             "GITHUB_SHA=${{ github.sha }}"
             "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
-            "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
-            "IMAGE_VERSION=${{ steps.dotenv.outputs.IMAGE_VERSION }}"
+            "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ needs.compute-versions-from-env.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
+            "IMAGE_VERSION=${{ needs.compute-versions-from-env.outputs.IMAGE_VERSION }}"
           provenance: false
           sbom: true
           pull: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,13 @@ jobs:
         id: docker_time_stamp
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
+        name: Get versions from .env file using Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+          keys-case: bypass
+      -
         name: Build
         uses: docker/build-push-action@v6
         with:
@@ -57,6 +64,8 @@ jobs:
             "NODE_VERSION=${{ matrix.version }}"
             "GITHUB_SHA=${{ github.sha }}"
             "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
+            "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
+            "IMAGE_VERSION=${{ steps.dotenv.outputs.IMAGE_VERSION }}"
           provenance: false
           sbom: false
           pull: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,62 @@
+name: Check for Version Bump, Create Automated Release
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  create-release-on-bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install semver-compare-cli
+        run: yarn && yarn add semver-compare-cli
+
+      - name: Get versions from .env file using Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+          keys-case: bypass
+
+      - name: Check for version update
+        id: version_check
+        run: |
+          echo "current version:" ${{ steps.dotenv.outputs.IMAGE_VERSION }}
+
+          RELEASE_VERSION=$(gh release list --exclude-drafts -L 1 --json tagName --jq '.[].tagName')
+          echo "latest (pre)release version:" $RELEASE_VERSION
+
+          if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $RELEASE_VERSION; then
+            echo "base-docker-image version updated from $RELEASE_VERSION to $CURRENT_VERSION, creating release"
+            echo "version_updated=true" >> $GITHUB_OUTPUT
+            echo "tag: v$CURRENT_VERSION"
+            echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "base-docker-image version not updated, will not release"
+            echo "version_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate a token
+        if: steps.version_check.outputs.version_updated == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASES_APP_ID }}
+          private-key: ${{ secrets.RELEASES_PRIVATE_KEY }}
+
+      - name: Create Release
+        if: steps.version_check.outputs.version_updated == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          prerelease: true
+          tag_name: ${{ steps.version_check.outputs.tag }}
+          name: ${{ steps.version_check.outputs.tag }}
+          generate_release_notes: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -56,7 +56,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          prerelease: true
+          make_latest: true
           tag_name: ${{ steps.version_check.outputs.tag }}
           name: ${{ steps.version_check.outputs.tag }}
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,13 +68,6 @@ jobs:
         id: docker_time_stamp
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
-        name: Get versions from .env file using Dotenv Action
-        id: dotenv
-        uses: falti/dotenv-action@v1.1.4
-        with:
-          log-variables: true
-          keys-case: bypass
-      -
         name: Build
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,8 @@ jobs:
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}
     
   slack-announcement:
+    # Only announce release when a release is published
+    if: github.event_name == 'release' && github.event.action == 'published'
     needs: [build_and_release_matrix, compute-versions-from-env]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,36 @@ env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/node-base
 
 jobs:
+  compute-versions-from-env:
+    runs-on: ubuntu-latest
+    outputs:
+      TERAFOUNDATION_KAFKA_CONNECTOR_VERSION: ${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}
+      IMAGE_VERSION: ${{ steps.dotenv.outputs.IMAGE_VERSION }}
+      NODE_VERSIONS_ARRAY: ${{ steps.dotenv.outputs.NODE_VERSIONS_ARRAY }}
+    steps:
+      -
+        name: Get versions from .env file using Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+          keys-case: bypass
+
   build_and_release_matrix:
+    needs: 'compute-versions-from-env'
     strategy:
       matrix:
-        # NOTE: These versions must be kept in sync with the build.yml
+        # NOTE: The NODE_VERSION_ARRAY is stored in the .env file.
         # In the case where a new node version introduces a breaking change,
-        # replace the major version of the matrix to a pinned version here.
+        # replace the major version of the matrix to a pinned version.
         # Ex: ["18", "20", "22"] ---> ["18.19.1", "20", "22"]
-        version: ["18", "20", "22"]
+        version: ${{ fromJSON(needs.compute-versions-from-env.outputs.NODE_VERSIONS_ARRAY) }}
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-    outputs: 
-      image_version: ${{ steps.dotenv.outputs.IMAGE_VERSION }}
 
     steps:
       -
@@ -67,8 +81,8 @@ jobs:
             "NODE_VERSION=${{ matrix.version }}"
             "GITHUB_SHA=${{ github.sha }}"
             "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
-            "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
-            "IMAGE_VERSION=${{ steps.dotenv.outputs.IMAGE_VERSION }}"
+            "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ needs.compute-versions-from-env.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
+            "IMAGE_VERSION=${{ needs.compute-versions-from-env.outputs.IMAGE_VERSION }}"
           provenance: false
           sbom: true
           pull: true
@@ -119,7 +133,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}
     
   slack-announcement:
-    needs: [build_and_release_matrix]
+    needs: [build_and_release_matrix, compute-versions-from-env]
     runs-on: ubuntu-latest
     steps:
       - name: Announce release in Slack releases channel
@@ -131,9 +145,9 @@ jobs:
           payload: |
             channel: ${{ vars.SLACK_RELEASES_CHANNEL_ID }}
             text: |
-              base-docker-image version `v${{ needs.build_and_release_matrix.outputs.image_version }}` has been released.
+              base-docker-image version `v${{ needs.compute-versions-from-env.outputs.IMAGE_VERSION }}` has been released.
               Please review and revise the automated release notes:
-              https://github.com/terascope/base-docker-image/releases/tag/v${{ needs.build_and_release_matrix.outputs.image_version }}
+              https://github.com/terascope/base-docker-image/releases/tag/v${{ needs.compute-versions-from-env.outputs.IMAGE_VERSION }}
               Docker images: https://github.com/terascope/base-docker-image/pkgs/container/node-base
 
       - name: Failed Announcement Response

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
             "IMAGE_VERSION=${{ steps.dotenv.outputs.IMAGE_VERSION }}"
           provenance: false
-          sbom: false
+          sbom: true
           pull: true
           push: true
           file: ./Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+    outputs: 
+      image_version: ${{ steps.dotenv.outputs.IMAGE_VERSION }}
 
     steps:
       -
@@ -116,6 +118,28 @@ jobs:
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }} ${{ env.IMAGE_NAME }}:${{ matrix.version }}
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}
     
+  slack-announcement:
+    needs: [build_and_release_matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Announce release in Slack releases channel
+        id: announce-release
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASES_CHANNEL_ID }}
+            text: |
+              base-docker-image version `v${{ needs.build_and_release_matrix.outputs.image_version }}` has been released.
+              Please review and revise the automated release notes:
+              https://github.com/terascope/base-docker-image/releases/tag/v${{ needs.build_and_release_matrix.outputs.image_version }}
+              Docker images: https://github.com/terascope/base-docker-image/pkgs/container/node-base
+
+      - name: Failed Announcement Response
+        if: ${{ steps.announce-release.outputs.ok == 'false' }}
+        run: echo "Slackbot API failure response - ${{ steps.announce-release.outputs.response }}"
+
 # I don't think we use the core images and we should consider removing this and the Dockerfile.core file.
       # -
       #   name: Build Core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
         id: docker_time_stamp
         run: echo "BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_ENV
       -
+        name: Get versions from .env file using Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+          keys-case: bypass
+      -
         name: Build
         uses: docker/build-push-action@v6
         with:
@@ -58,6 +65,8 @@ jobs:
             "NODE_VERSION=${{ matrix.version }}"
             "GITHUB_SHA=${{ github.sha }}"
             "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
+            "TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=${{ steps.dotenv.outputs.TERAFOUNDATION_KAFKA_CONNECTOR_VERSION }}"
+            "IMAGE_VERSION=${{ steps.dotenv.outputs.IMAGE_VERSION }}"
           provenance: false
           sbom: false
           pull: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
       NODE_VERSIONS_ARRAY: ${{ steps.dotenv.outputs.NODE_VERSIONS_ARRAY }}
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         name: Get versions from .env file using Dotenv Action
         id: dotenv
         uses: falti/dotenv-action@v1.1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# The default NODE_VERSION should stay in sync with the teraslice docker image default
 ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-ARG NODE_VERSION
+ARG NODE_VERSION=22.13.1
 FROM node:${NODE_VERSION}-alpine
 
 ARG GITHUB_SHA
 ARG BUILD_TIMESTAMP
+ARG TERAFOUNDATION_KAFKA_CONNECTOR_VERSION
+ARG IMAGE_VERSION
 
 RUN apk --no-cache add \
     bash \
@@ -55,7 +57,7 @@ RUN npm init --yes &> /dev/null \
     --build \
     --no-package-lock \
     --no-optional \
-    'terafoundation_kafka_connector@~1.2.1' \
+    terafoundation_kafka_connector@~$TERAFOUNDATION_KAFKA_CONNECTOR_VERSION \
     && npm cache clean --force
 
 RUN apk del .build-deps
@@ -77,8 +79,9 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
   org.opencontainers.image.title="Node-base" \
   org.opencontainers.image.vendor="Terascope" \
+  org.opencontainers.image.version="$IMAGE_VERSION" \
   io.terascope.image.node_version="$NODE_VERSION" \
-  io.terascope.image.kafka_connector_version="1.2.1"
+  io.terascope.image.kafka_connector_version="$TERAFOUNDATION_KAFKA_CONNECTOR_VERSION"
 
 # Use tini to handle sigterm and zombie processes
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 
-LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
+LABEL org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.documentation="https://github.com/terascope/base-docker-image/blob/master/README.md" \
   org.opencontainers.image.licenses="MIT License" \
   org.opencontainers.image.revision="$GITHUB_SHA" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=22.13.1
+ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-alpine
 
 ARG GITHUB_SHA
@@ -79,7 +79,7 @@ LABEL  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
   org.opencontainers.image.source="https://github.com/terascope/base-docker-image" \
   org.opencontainers.image.title="Node-base" \
   org.opencontainers.image.vendor="Terascope" \
-  org.opencontainers.image.version="$IMAGE_VERSION" \
+  io.terascope.image.base_version="$IMAGE_VERSION" \
   io.terascope.image.node_version="$NODE_VERSION" \
   io.terascope.image.kafka_connector_version="$TERAFOUNDATION_KAFKA_CONNECTOR_VERSION"
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Double check the action output before relying on the above commands.
 ## Release Workflow
 
 - Docker image builds will happen on any push to any branch other than `master`.
+- The `TERAFOUNDATION_KAFKA_CONNECTOR_VERSION` and `IMAGE_VERSION` build-args are specified in the `.env` file.
+- Merging to master will trigger an automated release if the `IMAGE_VERSION` has been increased in the `.env` file.
 - When a Github release is made, the image will be built and then pushed to
 the github container registry.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Double check the action output before relying on the above commands.
 
 ## Release Workflow
 
-- Docker image builds will happen on any push to any branch other than `master`.
+- Docker image builds will happen on any push to any branch other than `master`. These builds will have image tags ending in `-test`.
+- The `NODE_VERSIONS_ARRAY` in the `.env` file will determine which versions of the node-alpine base image will be used.
 - The `TERAFOUNDATION_KAFKA_CONNECTOR_VERSION` and `IMAGE_VERSION` build-args are specified in the `.env` file.
 - Merging to master will trigger an automated release if the `IMAGE_VERSION` has been increased in the `.env` file.
 - When a Github release is made, the image will be built and then pushed to


### PR DESCRIPTION
This PR makes the following changes:
- Add `.env` file to store `TERAFOUNDATION_KAFKA_CONNECTOR_VERSION`, `IMAGE_VERSION`, and `NODE_VERSION_ARRAY` 
- `release` and `build` workflows use `dotenv-action` to read `.env` file and pass versions to build-push-action
- `Dockerfile` now gets `TERAFOUNDATION_KAFKA_CONNECTOR_VERSION` and `IMAGE_VERSION` from build-args
- Add `merge.yml` workflow to trigger automated release if `IMAGE_VERSION` has increased in `.env` file
- Add slack announcement to `release` workflow
- Include sbom attestations in docker image builds
- bump version from 1.2.1-1 to 1.2.2

ref: #42 