### PR TITLE
Provide needed token when calling github cli in merge.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Check for version update
         id: version_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "current version:" ${{ steps.dotenv.outputs.IMAGE_VERSION }}
 


### PR DESCRIPTION
This PR adds the github token as an env variable to the `version-check` step. A token is required to call `gh release`.