### PR TITLE
update kafka connector and image version to 1.4.0

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@
 
 # If IMAGE_VERSION is updated then a new release 
 # will be created with that tag on merge to master
-IMAGE_VERSION=1.3.0
+IMAGE_VERSION=1.4.0
 
-TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.3.0
+TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.4.0
  
 NODE_VERSIONS_ARRAY=["18", "20", "22"]


### PR DESCRIPTION
This PR makes the following changes:
- update `IMAGE_VERSION` from 1.3.0 to 1.4.0
- update `TERAFOUNDATION_KAFKA_CONNECTOR_VERSION` from 1.3.0 to 1.4.0
  - node-rdkafka from 3.2.1 to 3.3.1
  - librdkafka from 2.6.1 to 2.8.0