### PR TITLE
bump terafoundation_kafka_connector to v1.5.1 and image_version to v1.6.1

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@
 
 # If IMAGE_VERSION is updated then a new release 
 # will be created with that tag on merge to master
-IMAGE_VERSION=1.6.0
+IMAGE_VERSION=1.6.1
 
-TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.5.0
+TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.5.1
  
 NODE_VERSIONS_ARRAY=["22", "24"]


### PR DESCRIPTION
This PR makes the following changes:
- bump terafoundation_kafka_connector from v1.5.0 to v1.5.1
- bump image_version from v1.6.0 to v1.6.1