### PR TITLE
pin node 24 version to 24.4

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,9 @@
 
 # If IMAGE_VERSION is updated then a new release 
 # will be created with that tag on merge to master
-IMAGE_VERSION=1.7.0
+IMAGE_VERSION=1.7.1
 
 TERAFOUNDATION_KAFKA_CONNECTOR_VERSION=1.6.0
  
-NODE_VERSIONS_ARRAY=["22", "24"]
+# Node 24 pinned see: https://github.com/terascope/teraslice/issues/4141
+NODE_VERSIONS_ARRAY=["22", "24.4"]


### PR DESCRIPTION
This PR makes the following changes:
- update node version array to pin node 24 to 24.4
- bump image version to 1.7.1